### PR TITLE
Update `extend` dependency for CVE-2018-16492

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "standard"
   },
   "dependencies": {
-    "extend": "2.*",
+    "extend": "^3.0.2",
     "q": "1.*",
     "rimraf": "2.*"
   },


### PR DESCRIPTION
This PR addresses [CVE-2018-16492](https://nvd.nist.gov/vuln/detail/CVE-2018-16492), which details a vulnerability in older versions of `extend`. 