### PR TITLE
Migrate to native Promises and remove Q dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ user's confirmation.
 * Prompt the user for confirmation, and raise an exception if the answer
   is negative.
 
+**Note:** This library requires Node.js v8.0.0 or higher as it uses native JavaScript promises and `util.promisify`.
+
 You can configure the following variables:
 
 | Name                        | Description                                                                                                                                            | Default                     |
@@ -36,7 +38,7 @@ The messages are:
 | `confirm`   | Text to prompt the user to confirm the (not empty) directory wipe.                  |
 | `abort`     | Error message when the user refuses to wipe the folder.                             |
 
-The function is asynchronous and return a promise. Nothing is passed to
+The function is asynchronous and returns a promise. Nothing is passed to
 the success function, but you'll get an `Error` instance in the error
 function. It can have the following `code` property:
 

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   },
   "dependencies": {
     "extend": "^3.0.2",
-    "q": "1.*",
     "rimraf": "2.*"
   },
   "devDependencies": {
     "standard": "^4.0.1"
+  },
+  "engines": {
+    "node": ">=8.0.0"
   }
 }


### PR DESCRIPTION
This resolves #7

- Replace Q promise library with native JavaScript Promises
- Use `util.promisify` instead of Q's `denodeify`
- Update package.json to specify Node.js v8.0.0+ requirement
- Update README to reflect Promise and Node.js version changes
- Remove Q dependency from package.json